### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main", "develop", "beta" ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/unsass/css/security/code-scanning/1](https://github.com/unsass/css/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow to apply to all jobs. Based on the workflow's actions, the minimal required permissions are `contents: read`. This ensures that the workflow has only the permissions it needs to function correctly, reducing the risk of unintended or malicious actions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
